### PR TITLE
fix: deal gracefully with warmup_steps=0

### DIFF
--- a/train.py
+++ b/train.py
@@ -563,7 +563,7 @@ if __name__ == '__main__':
 
     load_optimizer_states = config.get('load_optimizer_states', True)
     # if resuming and not loading optimizer states, we can't use warmup or the LR never changes from the initial value (still don't know why)
-    if 'warmup_steps' in config and load_optimizer_states:
+    if 'warmup_steps' in config and config['warmup_steps'] > 0 and load_optimizer_states:
         warmup_steps = config['warmup_steps']
         warmup_scheduler = torch.optim.lr_scheduler.LinearLR(optimizer, start_factor=1/warmup_steps, total_iters=warmup_steps)
         lr_scheduler = torch.optim.lr_scheduler.SequentialLR(optimizer, schedulers=[warmup_scheduler, lr_scheduler], milestones=[warmup_steps])


### PR DESCRIPTION
If a user sets warmup_steps to 0 (as opposed to commenting it out), the trainer will crash with a division by zero due to `start_factor` param in

https://github.com/tdrussell/qlora-pipe/blob/6336bd448e5dcc61e2e069283b612505df75bb84/train.py#L552

This PR disregards 0 case.
