### PR TITLE
improve steps logging including adding an ETA

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -1,3 +1,5 @@
+from collections import deque
+
 import torch
 from torch import nn
 
@@ -47,6 +49,7 @@ class CustomPipelineEngine(PipelineEngine):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.total_steps = None
+        self.etas = deque()
 
 
     def train_batch(self):
@@ -76,12 +79,16 @@ class CustomPipelineEngine(PipelineEngine):
                 elapsed = self.timers(TRAIN_BATCH_TIMER).elapsed(reset=True) / 1000.0
                 iter_time = elapsed / self.steps_per_print()
                 eta = iter_time * (self.total_steps - self.global_steps) / 3600
+                self.etas.append(eta)
+                while len(self.etas) > 10:
+                    self.etas.popleft()
+                rolling_eta = sum(self.etas) / len(self.etas)
                 tput = self.train_batch_size() / iter_time
                 log(f'step: {self.global_steps:>5} / {self.total_steps:>5} '
                     f'loss: {self.agg_train_loss:0.4f} '
                     f'iter time (s): {iter_time:0.3f} '
                     f'samples/sec: {tput:0.3f} '
-                    f'eta (h): {eta:0.3f}')
+                    f'eta (h): {rolling_eta:0.3f}')
             else:
                 self.timers(TRAIN_BATCH_TIMER).elapsed(reset=True)
 

--- a/train.py
+++ b/train.py
@@ -676,3 +676,6 @@ if __name__ == '__main__':
             )
 
         step += 1
+
+    if is_main_process():
+        print('TRAINING COMPLETE!')

--- a/train.py
+++ b/train.py
@@ -532,6 +532,7 @@ if __name__ == '__main__':
     )
     model_engine.set_dataloader(train_dataloader)
     steps_per_epoch = len(train_dataloader) // model_engine.gradient_accumulation_steps()
+    model_engine.total_steps = steps_per_epoch * config['epochs']
 
     if is_main_process():
         # Warn if eval dataset is unusually large compared to the eval steps

--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import sys
 import os.path
 import torch
@@ -7,3 +8,7 @@ sys.path.insert(0, os.path.abspath('axolotl/src'))
 from axolotl.utils.distributed import is_main_process, zero_first  # type: ignore # noqa
 
 DTYPE_MAP = {'float32': torch.float32, 'float16': torch.float16, 'bfloat16': torch.bfloat16}
+
+# Simplified logger-like printer.
+def log(msg):
+    print(f'[{datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]}] [INFO] [qlora-pipe] {msg}')


### PR DESCRIPTION
This adds a simplified log function to adopt the other time prefixed log messages, and updates the steps printer to include total steps, as well as an ETA in hours.

Also bonus encouraging completion message. Will drop if unnecessary, but the abrupt drop to prompt makes it not immediately  clear whether the thing keeled over or finished.