### PR TITLE
add old-state trimming and handle saving in new module

### DIFF
--- a/examples/config_7b.toml
+++ b/examples/config_7b.toml
@@ -51,6 +51,10 @@ lora_weight_dtype = 'bfloat16'
 # Can have the saved weights be different dtype. Don't need to set this. Could be useful for
 # training in float32 but saving with float16.
 #save_dtype = 'bfloat16'
+# Keep this number of stepXXXX (model saves) and global_stepXXX (checkpoint saves) and delete the rest
+# (this only applies to the current training session, and resumed training sessions will not touch
+# old saves)
+keep_states = 3
 
 # sort examples by length before dividing them into batches
 # this makes all examples in a batch approximately the same length, to minimize padding

--- a/saver.py
+++ b/saver.py
@@ -1,0 +1,185 @@
+import glob
+import json
+import os
+import re
+import shutil
+import time
+import deepspeed
+import torch
+import transformers
+
+from safetensors.torch import save_file
+from utils import is_main_process, DTYPE_MAP
+
+
+last_checkpoint_time = None
+def need_to_checkpoint(config):
+    global last_checkpoint_time
+    checkpoint = False
+    # rank 0 tracks if we need to checkpoint, broadcasts to everyone else
+    if is_main_process():
+        current_time = time.time()
+        if last_checkpoint_time is None:
+            last_checkpoint_time = current_time
+        elif (current_time - last_checkpoint_time) / 60 > config['checkpoint_every_n_minutes']:
+            checkpoint = True
+            last_checkpoint_time = current_time
+    result = [checkpoint]
+    torch.distributed.broadcast_object_list(result, src=0)
+    return result[0]
+
+
+def convert_state_dict_dtype(state_dict, dtype):
+    for key, v in state_dict.items():
+        state_dict[key] = v.to(device='cpu', dtype=DTYPE_MAP[dtype])
+
+
+class Saver:
+    def __init__(self, model_engine, pipeline_model, train_dataloader, lora_config, save_root, args, config):
+        self.model_engine = model_engine
+        self.pipeline_model = pipeline_model
+        self.train_dataloader = train_dataloader
+        self.lora_config = lora_config
+        self.save_root = save_root + '/' if save_root[-1] != '/' else save_root
+        self.args = args
+        self.config = config
+        self.keep_states = config.get('keep_states', -1)
+        self.chrono_states = {
+            'step': [],
+            'global_step': [],
+        }
+
+
+    # TODO: this is pretty hacky. Is there a way to get the state_dict from the lora model directly,
+    # but still know which layers the given pipeline parallel stage actually trained?
+    def save_lora(self, name):
+        dp_id = self.model_engine.grid.get_data_parallel_rank()
+        stage_id = self.model_engine.grid.get_pipe_parallel_rank()
+        save_dir = self.save_root + name
+        tmp_dir = os.path.join(save_dir, 'tmp')
+        if dp_id == 0 and stage_id == 0:
+            os.makedirs(tmp_dir, exist_ok=False)
+        deepspeed.comm.barrier()
+        if dp_id == 0:
+            partial_state_dict = {}
+            for name, p in self.pipeline_model.named_parameters():
+                if p.requires_grad:
+                    if not hasattr(p, 'original_name'):
+                        print(f'WARNING: parameter {name} requires_grad but does not have original_name. Not saving it.')
+                        continue
+                    partial_state_dict[p.original_name.replace('.default', '').replace('.modules_to_save', '')] = p
+                    if 'save_dtype' in self.config:
+                        convert_state_dict_dtype(partial_state_dict, self.config['save_dtype'])
+            torch.save(partial_state_dict, os.path.join(tmp_dir, f'state_dict_{stage_id}.bin'))
+        deepspeed.comm.barrier()
+        if dp_id == 0 and stage_id == 0:
+            state_dict = {}
+            for path in glob.glob(os.path.join(tmp_dir, '*.bin')):
+                state_dict.update(torch.load(path, map_location='cpu'))
+            torch.save(state_dict, os.path.join(save_dir, 'adapter_model.bin'))
+            self.lora_config.save_pretrained(save_dir)
+            shutil.copy(self.args.config, save_dir)
+            shutil.copy(self.args.deepspeed_config, save_dir)
+            shutil.rmtree(tmp_dir)
+
+
+    def save_full_model(self, name, max_shard_size='5GB'):
+        dp_id = self.model_engine.grid.get_data_parallel_rank()
+        stage_id = self.model_engine.grid.get_pipe_parallel_rank()
+        save_dir = self.save_root + name
+        tmp_dir = os.path.join(self.save_dir, 'tmp')
+        if dp_id == 0 and stage_id == 0:
+            os.makedirs(tmp_dir, exist_ok=False)
+        deepspeed.comm.barrier()
+        if dp_id == 0:
+            partial_state_dict = {p.original_name: p for p in self.pipeline_model.parameters()}
+            if 'save_dtype' in self.config:
+                convert_state_dict_dtype(partial_state_dict, self.config['save_dtype'])
+            torch.save(partial_state_dict, os.path.join(tmp_dir, f'state_dict_{stage_id}.bin'))
+        deepspeed.comm.barrier()
+        if dp_id == 0 and stage_id == 0:
+            state_dict = {}
+            for path in glob.glob(os.path.join(tmp_dir, '*.bin')):
+                state_dict.update(torch.load(path, map_location='cpu'))
+            shards, index = transformers.modeling_utils.shard_checkpoint(state_dict, max_shard_size=max_shard_size, weights_name='model.safetensors')
+            for shard_file, shard in shards.items():
+                save_file(shard, os.path.join(save_dir, shard_file), metadata={"format": "pt"})
+            if index is not None:
+                save_index_file = 'model.safetensors.index.json'
+                save_index_file = os.path.join(save_dir, save_index_file)
+                # Save the index as well
+                with open(save_index_file, "w", encoding="utf-8") as f:
+                    content = json.dumps(index, indent=2, sort_keys=True) + "\n"
+                    f.write(content)
+            shutil.copy(self.args.config, save_dir)
+            shutil.copy(self.args.deepspeed_config, save_dir)
+            additional_files_to_copy = [
+                'added_tokens.json',
+                'config.json',
+                'generation_config.json',
+                'special_tokens_map.json',
+                'tokenizer.json',
+                'tokenizer_config.json',
+                'tokenizer.model',
+            ]
+            for path in glob.glob(os.path.join(self.config['model'], '*')):
+                if os.path.basename(path) in additional_files_to_copy:
+                    shutil.copy(path, save_dir)
+            shutil.rmtree(tmp_dir)
+
+
+    def will_save(self, type, name):
+        if self.keep_states <= 0 or not is_main_process():
+            return
+        if type == 'step':
+            self.chrono_states['step'].append(name)
+            if len(self.chrono_states['step']) > self.keep_states:
+                print(f"Deleting {self.chrono_states['step'][0]}")
+                shutil.rmtree(os.path.join(self.save_root, self.chrono_states['step'].pop(0)))
+        elif type == 'global_step':
+            self.chrono_states['global_step'].append(name)
+            if len(self.chrono_states['global_step']) > self.keep_states:
+                print(f"Deleting {self.chrono_states['global_step'][0]}")
+                shutil.rmtree(os.path.join(self.save_root, self.chrono_states['global_step'].pop(0)))
+        else:
+            raise ValueError(f'Unknown save type: {type}')
+
+
+    def save_model(self, name):
+        # ignore epoch saves for chrono_states
+        if name.startswith("step"): 
+            self.will_save('step', name)
+        self.save_full_model(name) if self.lora_config is None else self.save_lora(name)
+
+
+    def save_checkpoint(self, step):
+        self.will_save('global_step', f'global_step{step}')
+        self.model_engine.save_checkpoint(
+            self.save_root,
+            client_state={
+                'step': step,
+                'custom_loader': self.train_dataloader.state_dict(),
+            },
+            save_latest=True,
+            exclude_frozen_parameters=True
+        )
+
+
+    def process_epoch(self, epoch, step):
+        if self.train_dataloader.epoch != epoch:
+            self.save_checkpoint(step)
+            self.save_model(f'epoch{epoch}')
+            epoch = self.train_dataloader.epoch
+            if epoch > self.config['epochs']:
+                return None
+            if is_main_process():
+                print(f'Started new epoch: {epoch}')
+        return epoch
+
+
+    def process_step(self, step):
+        if step % self.config['save_steps'] == 0:
+            self.save_model(f'step{step}')
+
+        if need_to_checkpoint(self.config):
+            self.save_checkpoint(step)

--- a/train.py
+++ b/train.py
@@ -19,12 +19,12 @@ import deepspeed
 from deepspeed.runtime.pipe.module import LayerSpec
 import toml
 import bitsandbytes
-from safetensors.torch import save_file
 from fastchat.conversation import register_conv_template, Conversation, SeparatorStyle
 from hqq.core import quantize as hqq_quantize
 
 from dataset_utils import load_datasets
 import dataloader
+from saver import Saver
 from utils import is_main_process, DTYPE_MAP
 import engine
 import llama_pipe
@@ -131,94 +131,6 @@ def evaluate(model_engine, eval_dataloaders, tb_writer, step, eval_gradient_accu
     duration = time.time() - start
     if is_main_process():
         tb_writer.add_scalar('eval/eval_time_sec', duration, step)
-
-
-def convert_state_dict_dtype(state_dict, dtype):
-    for key, v in state_dict.items():
-        state_dict[key] = v.to(device='cpu', dtype=DTYPE_MAP[dtype])
-
-
-# TODO: this is pretty hacky. Is there a way to get the state_dict from the lora model directly,
-# but still know which layers the given pipeline parallel stage actually trained?
-def save_lora(model_engine, pipeline_model, lora_config, save_dir, args, config):
-    dp_id = model_engine.grid.get_data_parallel_rank()
-    stage_id = model_engine.grid.get_pipe_parallel_rank()
-    tmp_dir = os.path.join(save_dir, 'tmp')
-    if dp_id == 0 and stage_id == 0:
-        os.makedirs(tmp_dir, exist_ok=False)
-    deepspeed.comm.barrier()
-    if dp_id == 0:
-        partial_state_dict = {}
-        for name, p in pipeline_model.named_parameters():
-            if p.requires_grad:
-                if not hasattr(p, 'original_name'):
-                    print(f'WARNING: parameter {name} requires_grad but does not have original_name. Not saving it.')
-                    continue
-                partial_state_dict[p.original_name.replace('.default', '').replace('.modules_to_save', '')] = p
-                if 'save_dtype' in config:
-                    convert_state_dict_dtype(partial_state_dict, config['save_dtype'])
-        torch.save(partial_state_dict, os.path.join(tmp_dir, f'state_dict_{stage_id}.bin'))
-    deepspeed.comm.barrier()
-    if dp_id == 0 and stage_id == 0:
-        state_dict = {}
-        for path in glob.glob(os.path.join(tmp_dir, '*.bin')):
-            state_dict.update(torch.load(path, map_location='cpu'))
-        torch.save(state_dict, os.path.join(save_dir, 'adapter_model.bin'))
-        lora_config.save_pretrained(save_dir)
-        shutil.copy(args.config, save_dir)
-        shutil.copy(args.deepspeed_config, save_dir)
-        shutil.rmtree(tmp_dir)
-
-
-def save_full_model(model_engine, pipeline_model, save_dir, args, config, max_shard_size='5GB'):
-    dp_id = model_engine.grid.get_data_parallel_rank()
-    stage_id = model_engine.grid.get_pipe_parallel_rank()
-    tmp_dir = os.path.join(save_dir, 'tmp')
-    if dp_id == 0 and stage_id == 0:
-        os.makedirs(tmp_dir, exist_ok=False)
-    deepspeed.comm.barrier()
-    if dp_id == 0:
-        partial_state_dict = {p.original_name: p for p in pipeline_model.parameters()}
-        if 'save_dtype' in config:
-            convert_state_dict_dtype(partial_state_dict, config['save_dtype'])
-        torch.save(partial_state_dict, os.path.join(tmp_dir, f'state_dict_{stage_id}.bin'))
-    deepspeed.comm.barrier()
-    if dp_id == 0 and stage_id == 0:
-        state_dict = {}
-        for path in glob.glob(os.path.join(tmp_dir, '*.bin')):
-            state_dict.update(torch.load(path, map_location='cpu'))
-        shards, index = transformers.modeling_utils.shard_checkpoint(state_dict, max_shard_size=max_shard_size, weights_name='model.safetensors')
-        for shard_file, shard in shards.items():
-            save_file(shard, os.path.join(save_dir, shard_file), metadata={"format": "pt"})
-        if index is not None:
-            save_index_file = 'model.safetensors.index.json'
-            save_index_file = os.path.join(save_dir, save_index_file)
-            # Save the index as well
-            with open(save_index_file, "w", encoding="utf-8") as f:
-                content = json.dumps(index, indent=2, sort_keys=True) + "\n"
-                f.write(content)
-        shutil.copy(args.config, save_dir)
-        shutil.copy(args.deepspeed_config, save_dir)
-        additional_files_to_copy = [
-            'added_tokens.json',
-            'config.json',
-            'generation_config.json',
-            'special_tokens_map.json',
-            'tokenizer.json',
-            'tokenizer_config.json',
-            'tokenizer.model',
-        ]
-        for path in glob.glob(os.path.join(config['model'], '*')):
-            if os.path.basename(path) in additional_files_to_copy:
-                shutil.copy(path, save_dir)
-        shutil.rmtree(tmp_dir)
-
-
-def save_model(model_engine, pipeline_model, lora_config, save_dir, args, config):
-    if lora_config is None:
-        save_full_model(model_engine, pipeline_model, save_dir, args, config)
-    else:
-        save_lora(model_engine, pipeline_model, lora_config, save_dir, args, config)
 
 
 def apply_max_norm_regularization(model, config):
@@ -390,23 +302,6 @@ def load_pipeline_model_with_lora(config, model_type):
             p.original_name = name
 
     return pipeline_model, lora_model, lora_config
-
-
-last_checkpoint_time = None
-def need_to_checkpoint():
-    global last_checkpoint_time
-    checkpoint = False
-    # rank 0 tracks if we need to checkpoint, broadcasts to everyone else
-    if is_main_process():
-        current_time = time.time()
-        if last_checkpoint_time is None:
-            last_checkpoint_time = current_time
-        elif (current_time - last_checkpoint_time) / 60 > config['checkpoint_every_n_minutes']:
-            checkpoint = True
-            last_checkpoint_time = current_time
-    result = [checkpoint]
-    torch.distributed.broadcast_object_list(result, src=0)
-    return result[0]
 
 
 if __name__ == '__main__':
@@ -631,6 +526,8 @@ if __name__ == '__main__':
     if config['eval_before_first_step'] and not config['resume_from_checkpoint']:
         evaluate(model_engine, eval_dataloaders, tb_writer, 0, eval_gradient_accumulation_steps)
 
+    saver = Saver(model_engine, pipeline_model, train_dataloader, lora_config, run_dir, args, config)
+
     while True:
         gc.collect()
         torch.cuda.empty_cache()
@@ -639,22 +536,9 @@ if __name__ == '__main__':
         if lora_config is not None:
             keys_scaled, avg_norm, max_norm, norms = apply_max_norm_regularization(pipeline_model, config)
 
-        if train_dataloader.epoch != epoch:
-            model_engine.save_checkpoint(
-                run_dir,
-                client_state={
-                    'step': step,
-                    'custom_loader': train_dataloader.state_dict(),
-                },
-                save_latest=True,
-                exclude_frozen_parameters=True
-            )
-            save_model(model_engine, pipeline_model, lora_config, f'{run_dir}/epoch{epoch}', args, config)
-            epoch = train_dataloader.epoch
-            if epoch > config['epochs']:
-                break
-            if is_main_process():
-                print(f'Started new epoch: {epoch}')
+        epoch = saver.process_epoch(epoch, step)
+        if epoch is None:
+            break
 
         if is_main_process() and step % config['logging_steps'] == 0:
             write_metrics(tb_writer, 'train', metrics, step)
@@ -667,22 +551,10 @@ if __name__ == '__main__':
                 tb_writer.add_histogram('train/weight_norm_hist', norms, step)
             tb_writer.add_scalar('train/epoch', step/steps_per_epoch, step)
 
-        if step % config['save_steps'] == 0:
-            save_model(model_engine, pipeline_model, lora_config, f'{run_dir}/step{step}', args, config)
-
         if step % config['eval_steps'] == 0:
             evaluate(model_engine, eval_dataloaders, tb_writer, step, eval_gradient_accumulation_steps)
 
-        if need_to_checkpoint():
-            model_engine.save_checkpoint(
-                run_dir,
-                client_state={
-                    'step': step,
-                    'custom_loader': train_dataloader.state_dict(),
-                },
-                save_latest=True,
-                exclude_frozen_parameters=True
-            )
+        saver.process_step(step)
 
         step += 1
 


### PR DESCRIPTION
Two things in this:

* Move save logic out of the train.py file.
* Add a `keep_states` option which lets you set the number of states (model saves and checkpoint saves) to keep. It discards excess states right before saving each time.

This is a rather big diff so I understand if you're hesitant to merge.

I think it's overall a step in the right direction, but you may have a different idea for how to address this.