### PR TITLE
bug-fix: use right varname in lm_head

### DIFF
--- a/llama_pipe.py
+++ b/llama_pipe.py
@@ -63,7 +63,7 @@ class LmHeadPipe(nn.Module):
         self.lm_head = lm_head
         self.logit_scale = logit_scale
         if tie_weights:
-            self.orig.weight.original_name = tie_weights
+            self.lm_head.weight.original_name = tie_weights
         loader_util.load_state_dict_into_module(self)
 
     def forward(self, inputs):


### PR DESCRIPTION
I'm pretty sure `orig` is `lm_head` here, as indicated in the comment above.

I crashed on this when I was playing around with `model_type` other than the default. Using `lm_head` seems to do the trick.
