### PR TITLE
LoRA+ support

### DIFF
--- a/train.py
+++ b/train.py
@@ -415,7 +415,6 @@ if __name__ == '__main__':
     parameters_to_train = [p for p in pipeline_model.parameters() if p.requires_grad]
 
     def get_optimizer(model_parameters):
-        breakpoint()
         optim_config = config['optimizer']
         lr = optim_config['lr']
         optim_type = optim_config['type'].lower()
@@ -438,6 +437,9 @@ if __name__ == '__main__':
             raise NotImplementedError(optim_type)
         if optim_config.get('use_loraplus', False):
             loraplus_lr_ratio = optim_config.get('loraplus_lr_ratio', 16)
+            # TODO: handle params being thrown out here; why is it included in the first place?
+            # delete 'params' from optimizer_kwargs
+            del optimizer_kwargs['params']
             return create_loraplus_optimizer(
                 model=pipeline_model,
                 optimizer_cls=optimizer_cls,


### PR DESCRIPTION
Some issues that need addressing, so keeping as draft.

- [ ] Deal with model params being passed around and then discarded when LoRA+ is used. Why are these even needed in DeepSpeed space? Can we just `None` them, or at least `None` them when LoRA+ is activated?
- [x] Wait for merge: https://github.com/huggingface/peft/pull/1973
- [x] Wait for next PEFT release