### PR TITLE
feature: proportional eval steps

### DIFF
--- a/examples/config_7b.toml
+++ b/examples/config_7b.toml
@@ -40,8 +40,17 @@ batch_size_tokens = 10000
 # Performance settings
 pipeline_stages = 1  # number of pipeline parallel stages, must evenly divide the number of GPUs you launch the script with
 logging_steps = 10  # how often to log in Tensorboard
-eval_steps = 100
-save_steps = 200
+
+# eval_proportion (float): How much time we should be spending doing evaluation vs training, between 0.0 and 0.10 or so.
+# This auto-calculates the eval_steps value, which must be commented out or removed if using eval proportion.
+eval_proportion = 0.05
+#eval_steps = 100
+
+# save_after_evals (numeric): How often we should save, given in number of evals.
+# Sets save_steps to eval_steps * save_after_evals.
+# Requires that save_steps is commented out or removed.
+save_after_evals = 2
+#save_steps = 200
 checkpoint_every_n_minutes = 60
 eval_before_first_step = true  # do an eval before any training happens
 # dtype to load the underlying model weights in


### PR DESCRIPTION
It's always hit and miss knowing what `eval_steps` to set for a good balance between time spent training vs time spent evaluating.

This code adds an auto-calibration eval step setter based on a proportion (0.00..1.00). It also adds a complementary save every X evals alternative to save_steps so that you can align saves with evals.

An optional 2nd commit includes the actual time spent on each step, printed out as it switches between training and evaluating. This is an example:

```
Trained for 8m19s. Running eval
before GAS splitting, batch size: 1, total tokens: 8128
[...]
before GAS splitting, batch size: 1, total tokens: 8128
Eval took 24s. Eval vs training: 4.96%
```
the above was with `eval_proportion = 0.05`. The actual time train/eval is usually very very close to the desired proportion, so your estimate is very accurate it looks like.

With 0.05, you will most likely get more evals than you are used to. I see eval_steps being set to 40 or 50 a lot of the times. We may want to default to 0.02 or 0.03 instead, to be closer to the current state.