### PR TITLE
Fixed "log_loss_hist" to work with float16

### DIFF
--- a/train.py
+++ b/train.py
@@ -80,7 +80,7 @@ def write_metrics(tb_writer, prefix, metrics, step):
         for quantile, value in zip(quantiles, loss_quantiles):
             tb_writer.add_scalar(f'{prefix}/loss_quantile_{quantile:.3f}', value, step)
         tb_writer.add_scalar(f'{prefix}/loss', rv, step)
-        tb_writer.add_histogram(f'{prefix}/log_loss_hist', torch.log(1e-10 + losses), step)
+        tb_writer.add_histogram(f'{prefix}/log_loss_hist', torch.log(1e-8 + losses), step)
 
     if len(metrics) >= 3:
         entropy = metrics[2].view(-1)


### PR DESCRIPTION
Fixed `torch.log(1e-10 + losses)` to work with `model_weight_dtype` of `float16`.

`float16` has a minimum sub-normal value of approx `5.96e−8`, so changed to use `1e-8` and now the histogram shows up correctly when using `float16`.