### PR TITLE
do not crash if eval_size is not set

### DIFF
--- a/dataset_utils.py
+++ b/dataset_utils.py
@@ -80,8 +80,8 @@ def load_raw_dataset(dataset_path, tokenizer, sequence_len, eval_size, overlap=0
 def load_axolotl_dataset(dataset_path, tokenizer, sequence_len, eval_size):
     with open(dataset_path, 'r') as f:
         cfg = yaml.safe_load(f.read())
-    if 'val_set_size' not in cfg and eval_size:
-        cfg['val_set_size'] = eval_size
+    if 'val_set_size' not in cfg:
+        cfg['val_set_size'] = 0 if eval_size is None else eval_size
     cfg['sequence_len'] = sequence_len
     cfg['tokenizer_config'] = 'dummy'
     # these two don't matter, but they have to be set


### PR DESCRIPTION
For configurations where eval dataset is explicitly set, the `eval_size` is not used or set to `0`. In both of these cases, due to the if case regarding eval_size == 0 as `not True`, the code will fail to set the `val_set_size cfg` param, resulting in a crash in Axolotl code, which assumes it is a numeric non-None value.

The relevant code is in https://github.com/axolotl-ai-cloud/axolotl/blob/cd2d89f4672e90af45c6a632c75a624b6219c712/src/axolotl/utils/data/sft.py#L523-L525

```py
    val_set_size = (
        int(cfg.val_set_size) if cfg.val_set_size > 1 else float(cfg.val_set_size)
    )
```