### PR TITLE
eval_after_last_step flag

### DIFF
--- a/examples/config.toml
+++ b/examples/config.toml
@@ -44,6 +44,7 @@ eval_steps = 100
 save_steps = 200
 checkpoint_every_n_minutes = 60
 eval_before_first_step = true  # do an eval before any training happens
+eval_after_last_step = false # do a final eval after the training completes
 # dtype to load the underlying model weights in
 model_weight_dtype = 'bfloat16'
 # dtype for the LoRA weights

--- a/train.py
+++ b/train.py
@@ -576,7 +576,7 @@ if __name__ == '__main__':
 
     epoch = train_dataloader.epoch
 
-    if 'eval_before_first_step' in config and config['eval_before_first_step'] and not resume_from_checkpoint:
+    if config.get('eval_before_first_step', False) and not resume_from_checkpoint:
         loss = evaluate(model_engine, eval_dataloaders, tb_writer, 0, eval_gradient_accumulation_steps)
         saver.append_eval_results(loss, save_best=False)
 
@@ -610,6 +610,10 @@ if __name__ == '__main__':
         saver.process_step(step)
 
         step += 1
+
+    if ((step - 1) % config['eval_steps'] != 0) and config.get('eval_after_last_step', False):
+        loss = evaluate(model_engine, eval_dataloaders, tb_writer, step - 1, eval_gradient_accumulation_steps)
+        saver.append_eval_results(loss)
 
     if is_main_process():
         print('TRAINING COMPLETE!')


### PR DESCRIPTION
It can be nice to have the final evaluation results after the training completes, as the last eval schedule may occur long before the final training step for higher eval steps. This enforces that an evaluation happens after the last step always, taking into account whether an eval happened already.

The flag is set to false in the example config, so people would have to explicitly turn it on to use it.