### PR TITLE
consider token# when calculating ETA

### DIFF
--- a/dataloader.py
+++ b/dataloader.py
@@ -11,7 +11,7 @@ from deepspeed import comm as dist
 from tqdm import tqdm
 
 from axolotl.utils.collators import DataCollatorForSeq2Seq
-from utils import is_main_process
+from utils import count_str, is_main_process
 
 # A100 wants padding to multiple of 64, other cards are efficient with smaller, so just do 64
 PAD_TO_MULTIPLE = 64
@@ -98,7 +98,7 @@ class DistributedBatchSamper(torch.utils.data.Sampler):
                 largest_global_batch = global_batch_idx
         global_batches[0], global_batches[largest_global_batch] = global_batches[largest_global_batch], global_batches[0]
         if is_main_process():
-            print(f"{self.total_tokens/1000000:.2f}M tokens")
+            print(f"{count_str(self.total_tokens)} tokens")
 
         batches_for_this_rank = [global_batch[self.rank:len(global_batch):self.num_replicas] for global_batch in global_batches]
         self.indices = [[i for i, _ in batch] for batch in batches_for_this_rank]

--- a/utils.py
+++ b/utils.py
@@ -18,3 +18,13 @@ def eta_str(eta):
     if eta > 3600:
         return f'{eta // 3600}h{(eta % 3600) // 60}m'
     return f'{eta // 60}m{eta % 60}s' if eta > 60 else f'{eta}s'
+
+def count_str(num):
+    num = int(num)
+    if num > 1000000000:
+        return f"{num/1000000000:.2f}G"
+    if num > 1000000:
+        return f"{num/1000000:.2f}M"
+    elif num > 1000:
+        return f"{num/1000:.2f}k"
+    return str(num)


### PR DESCRIPTION
Problem: current ETA fluctuates rather wildly depending on the number of tokens in recent steps.

This:

1. Tracks and counts the time spent processing each step based on the token count. This can be plotted as a 1-dimensional polynomial over the sample token count, i.e. a constant time per step + time for each token.
2. Tracks the time to do an eval run, and includes the remaining eval time in the ETA (5745c41def6c37879fb36e7c72520336b8b91638).
3. Tidies up the log message a bit, including turning per-second values upside down if they are < 1.

The ETA displays the expected date if ETA > 1h.

To get an idea of just how accurate this is, here is step 14/193 of a recent run I did:
```
[2024-11-13 23:59:47.780] [INFO] [qlora-pipe] step:    13 /   193 loss: 2.1119 tokens: 37120
[706.82k / 10.24M = 0.0690] tok/s: 1089.175 s/it: 34.081 samples/s: 0.117
eta: 2h27m 2024-11-14 02:26:50
```
and here is the final step:
```
[2024-11-14 02:35:12.024] [INFO] [qlora-pipe] step:   193 /   193 loss: 2.0039 tokens: 47104
[10.24M / 10.24M = 1.0000] tok/s: 1157.641 s/it: 40.690 samples/s: 0.098 eta: 0s
```
Since then, I added 5745c41def6c37879fb36e7c72520336b8b91638 which tracks and takes into account the remaining time for evaluations, which is the main reason for the discrepancy in the above (there were 2 evals taking 1m43s each, i.e. 3m20s, so the updated ETA would be 2024-11-14 02:30:10). This gives a ~3.4% error in the early estimate.

Burden: TODO on why `self.train_dataloader` is not set.