### PR TITLE
merge_lora: skip .gguf, .safetensors in copy stage

### DIFF
--- a/merge_lora.py
+++ b/merge_lora.py
@@ -64,6 +64,12 @@ for filepath in input_path.glob('*'):
     filepath = Path(filepath)
     if filepath.is_dir():
         continue
+    if filepath.suffix == ".gguf":
+        # Skip unrelated stray quantizations
+        continue
+    if filepath.suffix == ".safetensors":
+        # Consolidated, possibly
+        continue
     print(f'copying {filepath.name} to output')
     shutil.copy(filepath, output_path)
 


### PR DESCRIPTION
I very often find that a merge results in copying a stray gguf file and, for recent Mistral models, the consolidated.safetensors file is caught up in the mix as well.

This simply skips over the offending types (.gguf, .safetensors).