### PR TITLE
First draft of `apply_lora_norm_regularization`

### DIFF
--- a/train.py
+++ b/train.py
@@ -173,11 +173,11 @@ def apply_lora_norm_regularization(model, config, lr):
     # max-norm stuff modified from https://github.com/kohya-ss/sd-scripts/blob/main/networks/lora.py
     norms = []
     keys_scaled = 0
-    
+
     lora_scale = config['lora_alpha'] / config['lora_rank']
     weight_decay = config.get('lora_weight_decay', 0.0)
     max_norm = config.get('lora_max_norm', 0.0)
-    
+
     for name, param in model.named_parameters():
         if 'lora_A' in name:
             A = param
@@ -186,7 +186,7 @@ def apply_lora_norm_regularization(model, config, lr):
             
             with torch.no_grad():
                 W = lora_scale * (B @ A)
-    
+
                 # Apply decoupled weight decay (indirectly) to the composite matrix BA if specified
                 # Using L = λ⋅½||W||_F²:
                 #    ∂L/∂W = λ⋅W, as ∂(½||W||_F²)/∂W = W
@@ -218,13 +218,13 @@ def apply_lora_norm_regularization(model, config, lr):
     if len(norms) > 0:
         norms = torch.tensor(norms, dtype=torch.float32)
         if torch.any(torch.isnan(norms)):
-            raise RuntimeError('NaN detected in norms, probably some/all weights are NaN')
-        avg_norm = norms.mean().item()
-        max_norm_val = norms.max().item()
+            raise RuntimeError(f'NaN detected in norms, probably some/all weights are NaN')
+        avg_norm = sum(norms) / len(norms)
+        max_norm = max(norms)
     else:
-        avg_norm = 0.0
-        max_norm_val = 0.0
-    return keys_scaled, avg_norm, max_norm_val, norms
+        avg_norm = 0
+        max_norm = 0
+    return keys_scaled, avg_norm, max_norm, norms
 
 
 def parse_layers_to_transform(spec):

--- a/train.py
+++ b/train.py
@@ -195,8 +195,8 @@ def apply_lora_norm_regularization(model, config, lr):
                 if weight_decay > 0:                      
                     grad_A = weight_decay * lora_scale * (B.t() @ W)
                     grad_B = weight_decay * lora_scale * (W @ A.t())
-                    A -= lr * grad_A
-                    B -= lr * grad_B
+                    A.sub_(lr * grad_A)
+                    B.sub_(lr * grad_B)
                     W = lora_scale * (B @ A)
     
                 # Apply max-norm regularisation if specified
@@ -207,8 +207,8 @@ def apply_lora_norm_regularization(model, config, lr):
                     if ratio != 1:
                         keys_scaled += 1
                         sqrt_ratio = ratio ** 0.5
-                        A *= sqrt_ratio
-                        B *= sqrt_ratio
+                        A.mul_(sqrt_ratio)
+                        B.mul_(sqrt_ratio)
                 else:
                     ratio = 1.0
         


### PR DESCRIPTION
So now instead of `apply_max_norm_regularization` we have `apply_lora_norm_regularization`:

- The old `scale_weight_norms` parameter has been renamed to `lora_max_norm`.
- The new `lora_weight_decay` parameter applies decoupled weight-decay to the composite matrix `W = s⋅BA`.

I manually calculated the gradients needed for the loss augmented with a L2-regularisation term:

$$
L' = L + \lambda \cdot \frac{1}{2}\sum_i \lVert W_i \rVert_F^2
$$
and using:
$$
\frac{\partial(\frac{1}{2}\lVert W \rVert_F^2)}{\partial W} = W
$$
we get:
$$
\frac{\partial L'}{\partial W_i} = \lambda  \cdot  W_i
$$
and noting that:
$$
W_i = s \cdot B_i A_i
$$
we get:
$$
\frac{\partial L'}{\partial A_i} = s \cdot B_i^T\frac{\partial L'}{\partial W_i} = \lambda \cdot s \cdot B_i^TW_i
$$
$$
\frac{\partial L'}{\partial B_i} = s \cdot \frac{\partial L'}{\partial W_i}A_i^T = \lambda \cdot s \cdot W_iA_i^T
$$

But to apply "decoupled" weight-decay:

![image](https://github.com/user-attachments/assets/8cfa27f1-729e-453b-a6d5-ba7a0a8eb212)

We use AdamW (or any other momentum-based optimiser) to optimise the original loss term:

$$
L' = L + ...
$$

and then standard SGD (*without* momentum) to optimise the regularisation term:

$$
L' = ... + \lambda \cdot \frac{1}{2}\sum_i \lVert W_i \rVert_F^2
$$

(*using the same scheduled value of `lr` for both updates!*)

In essence:

- This new "LoRA" weight-decay is a "soft" version of max-norm regularisation, and penalises `W` the larger the L2-ball.
- Max-norm regularisation is performing projected gradient descent by projecting the `W` back onto an L2-ball.
- The `lora_weight_decay` parameter is used to increase or decrease the "soft" penalty.
- The `lora_max_norm`parameter is used to set the radius of the L2-ball "hard" penally.

**NOTE**: There is some logic in the old code that came from the original [lora.py](https://github.com/kohya-ss/sd-scripts/blob/main/networks/lora.py) that doesn't project small-norm `W` ***outwards*** onto the L2-ball (IIRC, the threshold is half the value of `lora_max_norm`). This is all left the same as before, as without reading the paper this came from; I have to assume this is correct...

---

### IMPORTANT:

- I haven't actually tested this code and hence why it is a "draft"  PR (I have tested the use of `model.named_parameters()` in some other regularisation code and can confirm it works though...).
- Whatever `weight_decay` you used before (ie: that was applied to `lora_A` and `lora_B` separately) should be ***squared*** for use with the new `lora_weight_decay` parameter (eg: `0.1` before would be `0.01` now).
- Be sure to set `weight_decay = 0.0` in the `[optimizer]` sub-section so as not to "double-regularise" the weights! The default value is set to `0.01` so it ***must*** be set to zero.
- The changes should have no effect on full fine-tuning, for which you should use the `weight_decay` in the `[optimizer]` section as normal (but notice now that `weight_decay` in the `[optimizer]` section is on the same scale as the new `lora_weight_decay` parameter!).
- Using a mix of full fine-tuning (via `"modules_to_save"`) and LoRA won't allow mixing the two different `weight_decay` settings currently.

---

### TODO:

- Please can somebody (@kallewoof :grin:) test if this works by setting a really high value of `lora_weight_decay`?
- Please can somebody (@tdrussell :grin:) check if my use of `model.named_parameters()` is correct and will work with models split using pipeline-parallel? The LLMs I've asked are adamant that `model.state_dict()` won't work as it makes a copy and from what I read `model.named_modules()` will likely get all the modules; rather than just those on the current pipeline stage?

Sorry I can't test it today as have some other stuff I need to work on - I'm fairly confident the maths is correct though as tested via a test driver to make sure it matches up...