### PR TITLE
Both `LlamaForCausalLMPipe` and `Qwen2ForCausalLMPipe` should detect `"tie_word_embeddings": true`

### DIFF
--- a/llama_pipe.py
+++ b/llama_pipe.py
@@ -225,7 +225,7 @@ class LlamaForCausalLMPipe(PipelineModel, transformers.LlamaForCausalLM):
             LmHeadPipe,
             self.loader_util,
             self.lm_head,
-            tie_weights='model.embed_tokens.weight' if self.config.get('tie_word_embeddings', False) else None,
+            tie_weights='model.embed_tokens.weight' if self.config.tie_word_embeddings else None,
             _estimated_size=0
         ))
         result.append(

--- a/llama_pipe.py
+++ b/llama_pipe.py
@@ -276,7 +276,7 @@ class Qwen2ForCausalLMPipe(PipelineModel, transformers.Qwen2ForCausalLM):
             LmHeadPipe,
             self.loader_util,
             self.lm_head,
-            tie_weights='model.embed_tokens.weight' if self.config.get('tie_word_embeddings', False) else None,
+            tie_weights='model.embed_tokens.weight' if self.config.tie_word_embeddings else None,
             _estimated_size=0
         ))
         result.append(

--- a/llama_pipe.py
+++ b/llama_pipe.py
@@ -221,7 +221,13 @@ class LlamaForCausalLMPipe(PipelineModel, transformers.LlamaForCausalLM):
         for block in self.model.layers:
             result.append(LayerSpec(LlamaDecoderLayerPipe, self.loader_util, block))
         result.append(LayerSpec(LlamaRMSNormPipe, self.loader_util, self.model.norm, _estimated_size=0))
-        result.append(LayerSpec(LmHeadPipe, self.loader_util, self.lm_head, _estimated_size=0))
+        result.append(LayerSpec(
+            LmHeadPipe,
+            self.loader_util,
+            self.lm_head,
+            tie_weights='model.embed_tokens.weight' if self.config.get('tie_word_embeddings', False) else None,
+            _estimated_size=0
+        ))
         result.append(
             LayerSpec(
                 ComputeMetrics,
@@ -266,7 +272,13 @@ class Qwen2ForCausalLMPipe(PipelineModel, transformers.Qwen2ForCausalLM):
         for block in self.model.layers:
             result.append(LayerSpec(LlamaDecoderLayerPipe, self.loader_util, block))
         result.append(LayerSpec(LlamaRMSNormPipe, self.loader_util, self.model.norm, _estimated_size=0))
-        result.append(LayerSpec(LmHeadPipe, self.loader_util, self.lm_head, _estimated_size=0))
+        result.append(LayerSpec(
+            LmHeadPipe,
+            self.loader_util,
+            self.lm_head,
+            tie_weights='model.embed_tokens.weight' if self.config.get('tie_word_embeddings', False) else None,
+            _estimated_size=0
+        ))
         result.append(
             LayerSpec(
                 ComputeMetrics,


### PR DESCRIPTION
Fixes #30.

Both `LlamaForCausalLMPipe` and `Qwen2ForCausalLMPipe` should now detect the presence of:

```json
  "tie_word_embeddings": true,
```

and if set true, pass `tie_weights='model.embed_tokens.weight'` to the `LmHeadPipe` call.

https://huggingface.co/unsloth/Llama-3.2-1B-Instruct/blob/main/config.json

![image](https://github.com/user-attachments/assets/889ec4e1-a578-4f0b-8017-110f37a995da)

https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct/blob/main/config.json

![image](https://github.com/user-attachments/assets/c13dbb17-fd25-49fa-afcd-bab158980d58)