### PR TITLE
Use optim_config for lr_min

### DIFF
--- a/train.py
+++ b/train.py
@@ -549,8 +549,8 @@ if __name__ == '__main__':
             "optimizer": optimizer,
             "T_max": total_steps,
         }
-        if 'lr_min' in config:
-            lr_scheduler_kwargs["eta_min"] = config["lr_min"]
+        if 'lr_min' in optim_config:
+            lr_scheduler_kwargs["eta_min"] = optim_config["lr_min"]
 
         # Normally, you would pass the lr_scheduler to deepspeed.initialize(). But we need the
         # global batch_size in order to make the lr_scheduler.


### PR DESCRIPTION
The lr and lr_min should ideally be in the same place. This code moves the lr_min from the global config to inside [optimizer] to be with lr.

I actually didn't even realize I made the mistake until a training run silently ignored my lr_min and went down to 0.