### PR TITLE
Fix `yield_sequences_from_token_batch` to avoid losing the removed token when `BOS` is prepended

### DIFF
--- a/dataset_utils.py
+++ b/dataset_utils.py
@@ -31,6 +31,7 @@ def yield_sequences_from_token_batch(tokenizer, token_batch, sequence_len):
                 # Force each sequence to start with BOS.
                 # TODO: can we do this better? It's possible that the first token is EOS followed by BOS.
                 if tokenizer.bos_token_id is not None and example_tokens[0] != tokenizer.bos_token_id:
+                    tokens = [example_tokens[-1]] + tokens
                     example_tokens = [tokenizer.bos_token_id] + example_tokens[:-1]
                 yield example_tokens
                 need = sequence_len


### PR DESCRIPTION
I've just been experimenting with setting `batch_size_tokens` >> `sequence_len` and noticed one token was getting lost for each `BOS` insertion.

I think this is the correct solution and prepends it back to the `tokens` list for reuse? It's possibly not very efficient but not sure it makes much difference due to training taking so long comparably?