### PR TITLE
bug-fix: ceil the steps_per_epoch value to avoid unexpected extra final step

### DIFF
--- a/train.py
+++ b/train.py
@@ -512,7 +512,7 @@ if __name__ == '__main__':
         batch_size_tokens=None if 'batch_size_tokens' not in config else config['batch_size_tokens'],
     )
     model_engine.set_dataloader(train_dataloader)
-    steps_per_epoch = len(train_dataloader) // model_engine.gradient_accumulation_steps()
+    steps_per_epoch = (len(train_dataloader) + model_engine.gradient_accumulation_steps() - 1) // model_engine.gradient_accumulation_steps()
     model_engine.total_steps = steps_per_epoch * config['epochs']
 
     if is_main_process():
@@ -529,7 +529,7 @@ if __name__ == '__main__':
         print(f'eval_data_length: {eval_data_length}, eval_steps: {config["eval_steps"]}; evals per epoch: {evals_per_epoch}. '
               f'We will be spending approximately {fraction_evaling*100:.2f}% of our time evaluating.')
         if fraction_evaling > 0.15:
-            print(f'WARNING: eval dataset is unusually large compared to eval_steps. We will spend a lot of time evaluating. Lowering eval_size and/or bumping eval_steps is recommended.')
+            print('WARNING: eval dataset is unusually large compared to eval_steps. We will spend a lot of time evaluating. Lowering eval_size and/or bumping eval_steps is recommended.')
         print()
 
     # handle Deepspeed optimizer wrapper (e.g. BF16_Optimizer)


### PR DESCRIPTION
Recent runs see an extra step at the very end of the training run (e.g. step 101/100). This is possibly due to the steps_per_epoch being truncated for cases when the training batch count is not evenly divisible by the GAS.