### PR TITLE
Slightly improved version of `yield_sequences_from_token_batch`

### DIFF
--- a/dataset_utils.py
+++ b/dataset_utils.py
@@ -18,30 +18,29 @@ NUM_PROC = min(64, os.cpu_count())
 
 
 def yield_sequences_from_token_batch(tokenizer, token_batch, sequence_len):
-    need = sequence_len
-    example_tokens = []
+    sequence_tokens = [tokenizer.bos_token_id] if tokenizer.bos_token_id is not None else []
     for tokens in tqdm(token_batch):
         tokens = tokens.tolist()
-        assert tokens[-1] != tokenizer.eos_token_id, tokens[-1]
+        assert len(tokens) > 0, "empty tokens list"
+        assert tokens[-1] != tokenizer.eos_token_id, f"token list already ends with EOS: {tokens[-1]}"
         tokens.append(tokenizer.eos_token_id)
-        while len(tokens) > 0:
-            taken = tokens[:need]
-            tokens = tokens[need:]
-            need -= len(taken)
-            example_tokens.extend(taken)
-            if len(example_tokens) >= sequence_len:
-                assert len(example_tokens) == sequence_len
-                # Force each sequence to start with BOS.
-                # TODO: can we do this better? It's possible that the first token is EOS followed by BOS.
-                if tokenizer.bos_token_id is not None and example_tokens[0] != tokenizer.bos_token_id:
-                    example_tokens = [tokenizer.bos_token_id] + example_tokens[:-1]
-                yield example_tokens
-                need = sequence_len
-                example_tokens = []
+        idx = 0
+        # If present, skip the auto-generated BOS token
+        if tokenizer.bos_token_id is not None and tokens[0] == tokenizer.bos_token_id:
+            idx += 1
+        while idx < len(tokens):
+            need = sequence_len - len(sequence_tokens)
+            taken = tokens[idx:idx + need]
+            idx += len(taken)
+            sequence_tokens.extend(taken)
+            if len(sequence_tokens) >= sequence_len:
+                assert len(sequence_tokens) == sequence_len
+                yield sequence_tokens
+                sequence_tokens = [tokenizer.bos_token_id] if tokenizer.bos_token_id is not None else []
     # yield anything remaining
     # TODO: disabled until I get training working with variable length sequences
-    # if len(example_tokens) > 0:
-    #     yield example_tokens
+    # if len(sequence_tokens) > 0:
+    #     yield sequence_tokens
 
 
 def slice_into_chunks(x, sequence_len, overlap=0):

--- a/dataset_utils.py
+++ b/dataset_utils.py
@@ -61,6 +61,7 @@ def load_raw_dataset(dataset_path, tokenizer, sequence_len, eval_size, overlap=0
         dataset = datasets.load_dataset('json', data_files=dataset_path)['train']
     else:
         raise NotImplementedError()
+    dataset.set_format(type='torch')
 
     if subsample_documents:
         dataset = dataset.shuffle(seed=13).select(list(range(int(subsample_documents*len(dataset)))))
@@ -70,10 +71,6 @@ def load_raw_dataset(dataset_path, tokenizer, sequence_len, eval_size, overlap=0
     #dataset = dataset.map(lambda x: {'tokens': slice_into_chunks(x['tokens'][0], sequence_len, overlap=overlap)}, batched=True, batch_size=1)
     dataset = dataset.map(lambda x: {'input_ids': list(yield_sequences_from_token_batch(tokenizer, x['input_ids'], sequence_len))}, batched=True, batch_size=None, remove_columns=dataset.column_names, desc='splitting')
     dataset = dataset.map(lambda x: {'attention_mask': torch.ones_like(x['input_ids']), 'labels': x['input_ids']}, desc='adding attention_mask and labels')
-    
-    # Must be done *AFTER* the calls to dataset.map() to avoid OOM errors for very large files!
-    dataset.set_format(type='torch')
-    
     if eval_size > 0:
         split_datasets = dataset.train_test_split(test_size=eval_size, shuffle=True, seed=42)
         train_data = split_datasets['train']

--- a/dataset_utils.py
+++ b/dataset_utils.py
@@ -18,17 +18,19 @@ NUM_PROC = min(64, os.cpu_count())
 
 
 def yield_sequences_from_token_batch(tokenizer, token_batch, sequence_len):
+    # Initialize sequence_tokens with BOS token if it exists
     sequence_tokens = [tokenizer.bos_token_id] if tokenizer.bos_token_id is not None else []
     for tokens in tqdm(token_batch):
         tokens = tokens.tolist()
-        assert len(tokens) > 0, "empty tokens list"
-        assert tokens[-1] != tokenizer.eos_token_id, f"token list already ends with EOS: {tokens[-1]}"
+        assert len(tokens) > 0, "Empty tokens list"
+        assert tokens[-1] != tokenizer.eos_token_id, f"Token list already ends with EOS: {tokens[-1]}"
         tokens.append(tokenizer.eos_token_id)
         idx = 0
-        # If present, skip the auto-generated BOS token
+        # Skip the auto-generated BOS token if present
         if tokenizer.bos_token_id is not None and tokens[0] == tokenizer.bos_token_id:
             idx += 1
         while idx < len(tokens):
+            # Calculate how many tokens are needed to fill the sequence
             need = sequence_len - len(sequence_tokens)
             taken = tokens[idx:idx + need]
             idx += len(taken)
@@ -36,6 +38,7 @@ def yield_sequences_from_token_batch(tokenizer, token_batch, sequence_len):
             if len(sequence_tokens) >= sequence_len:
                 assert len(sequence_tokens) == sequence_len
                 yield sequence_tokens
+                # Reset sequence_tokens with BOS token if it exists
                 sequence_tokens = [tokenizer.bos_token_id] if tokenizer.bos_token_id is not None else []
     # yield anything remaining
     # TODO: disabled until I get training working with variable length sequences


### PR DESCRIPTION
This is a slightly improved version of `yield_sequences_from_token_batch`:

- Doesn't overwrite the first token of each sequence with the `BOS` token.
- Slightly less list slicing operations .

The logic for the `BOS` tokens is a little simpler too. AFAIK, the `"add_bos_token": true` option in `tokenizer_config.json` is actually often ignored and that's why you often see Jinga2 templates with `"template": "{{ bos_token }}...` in them even when `"add_bos_token": true`  is set.

---

This was actually just part of another branch where I tried all sorts to see if I could fix `load_raw_dataset` to work with very large files and/or lots of small files:

- I get an OOM error inside `dataset.set_format(type='torch')` when trying to pass it a single ~500MB text file (on a machine with 512GB of RAM!).
- It times out when I tried to give it 1.1M tiny files that add up to the same ~500MB. I even tried using `export DEEPSPEED_TIMEOUT=60` and it still timed out (using exactly 1 core of an 88 core machine!).

The things I tried:

- Using streaming for the `datasets.load_dataset()` call - doesn't work with the rest of the code.
- Moving the `dataset.set_format(type='torch')` to after the `dataset.map()` calls - `tokens.tolist()` doesn't work with the "arrow" type.
- A few other things I can't remember that `o1-preview` suggested (none did anything really).

(so I gave up and just went back to partitioning the same 500MB of text into 10MB files using bash scripts... :rofl:)

There must be some really bad O(n^2) algorithm inside of the `dataset.map()` as it still uses a baffling amount of RAM (50-80GB!) to deal with such a comparably small amount of text data...