### PR TITLE
Add final hidden-state metrics

### DIFF
--- a/train.py
+++ b/train.py
@@ -79,7 +79,13 @@ def write_metrics(tb_writer, prefix, metrics, step):
                 tb_writer.add_scalar(f'{prefix}/loss_quantile_{quantile:.3f}', value, step)
 
     if len(metrics) > 2:
-        entropy = metrics[2].view(-1)
+        hidden_norm_avg = metrics[2].mean().item()
+        tb_writer.add_scalar(f'{prefix}/hidden_norm_avg', hidden_norm_avg, step)
+        hidden_state_norms = metrics[2].view(-1)
+        tb_writer.add_histogram(f'{prefix}/hidden_norm_hist',  hidden_state_norms, step)
+
+    if len(metrics) > 3:
+        entropy = metrics[3].view(-1)
         tb_writer.add_scalar(f'{prefix}/entropy', entropy.mean().item(), step)
         if not args.no_quantiles:
             assert entropy.size() == losses.size(), (entropy.size(), losses.size())
@@ -90,8 +96,8 @@ def write_metrics(tb_writer, prefix, metrics, step):
             for quantile, value in zip(quantiles, entropy_quantiles):
                 tb_writer.add_scalar(f'{prefix}/entropy_quantile_{quantile:.3f}', value, step)
 
-    if len(metrics) > 3:
-        normalised_entropy = metrics[3].view(-1)
+    if len(metrics) > 4:
+        normalised_entropy = metrics[4].view(-1)
         tb_writer.add_scalar(f'{prefix}/normalised_entropy', normalised_entropy.mean().item(), step)
         if not args.no_quantiles:
             assert normalised_entropy.size() == losses.size()
@@ -102,30 +108,31 @@ def write_metrics(tb_writer, prefix, metrics, step):
             for quantile, value in zip(quantiles, normalised_entropy_quantiles):
                 tb_writer.add_scalar(f'{prefix}/normalised_entropy_quantile_{quantile:.3f}', value, step)
 
-    if len(metrics) > 4:
-        log_likelihood = metrics[4].mean()
+    if len(metrics) > 5:
+        log_likelihood = metrics[5].mean()
         tb_writer.add_scalar(f'{prefix}/log_likelihood', log_likelihood.item(), step)
         likelihood = torch.exp(-log_likelihood).item()
         tb_writer.add_scalar(f'{prefix}/likelihood', likelihood, step)
         perplexity = torch.exp(log_likelihood).item()
         tb_writer.add_scalar(f'{prefix}/perplexity', perplexity, step)
 
-    if len(metrics) > 5:
-        mcfaddens_pseudo_r2 = metrics[5].mean()
+    if len(metrics) > 6:
+        mcfaddens_pseudo_r2 = metrics[6].mean()
         tb_writer.add_scalar(f'{prefix}/mcfaddens_pseudo_r2', mcfaddens_pseudo_r2.item(), step)
 
-    if len(metrics) > 6:
-        tb_writer.add_scalar(f'{prefix}/top1_accuracy', metrics[6].mean().item(), step)
-        tb_writer.add_scalar(f'{prefix}/top5_accuracy', metrics[7].mean().item(), step)
-        tb_writer.add_scalar(f'{prefix}/top20_accuracy', metrics[8].mean().item(), step)
-
-    if len(metrics) > 9:
-        tb_writer.add_scalar(f'{prefix}/load_balancing_loss', metrics[9].mean().item(), step)
+    if len(metrics) > 7:
+        tb_writer.add_scalar(f'{prefix}/top1_accuracy', metrics[7].mean().item(), step)
+        tb_writer.add_scalar(f'{prefix}/top5_accuracy', metrics[8].mean().item(), step)
+        tb_writer.add_scalar(f'{prefix}/top20_accuracy', metrics[9].mean().item(), step)
 
     if len(metrics) > 10:
-        tb_writer.add_scalar(f'{prefix}/alternate_load_balancing_loss', metrics[10].mean().item(), step)
+        tb_writer.add_scalar(f'{prefix}/load_balancing_loss', metrics[10].mean().item(), step)
+
+    if len(metrics) > 11:
+        tb_writer.add_scalar(f'{prefix}/alternate_load_balancing_loss', metrics[11].mean().item(), step)
 
     return loss
+
 
 def evaluate_single(model_engine, name, eval_dataloader, tb_writer, step, eval_gradient_accumulation_steps):
     orig_micro_batches = model_engine.micro_batches


### PR DESCRIPTION
This PR adds `hidden_norm_avg` and `hidden_norm_hist` metrics:

![image](https://github.com/user-attachments/assets/e56b5460-7328-4676-b1b8-a2fe47a7779f)

It uses the hidden-state before it is multiplied by `self.logit_scale`.

The reason this is useful is because all the Focal Loss variants tend to "cheat" (by shrinking the hidden states) after you scale `gamma` beyond a certain point.

This should let you monitor this effect and then use Focal Loss to increase the Entropy of the models' outputs only up to the point where the balance of shrinking the hidden states outweighs the increase in log-loss caused by the attention blocks all having their inputs from the residual-stream down-scaled.

You can see the effect of `gamma=1.1` for Focal Loss\* in the pink lines - this is a continuation of the model with the grey line, which was previously trained using stock Cross-Entropy loss on the exact same dataset:

![image](https://github.com/user-attachments/assets/a7ebca4c-1d79-4559-9089-b0a37ad591f9)

I think the strange shape of the histogram in the first diagram is likely due to multi-word tokenisation: none-word-start tokens likely have much less Entropy than word-start tokens, etc.

The smaller the hidden state the smaller the dot-products with `lm_head` will be, which in turn increases the [scale parameter of the Gumbel-distributed errors](https://en.wikipedia.org/wiki/Gumbel_distribution) by compressing the x-axis that the logits are projected onto, which in turn causes more overlap in the integral that Softmax if performing and this ultimately leads to higher Entropy...

Ideally ,we want to use the Focal Loss variants to cause these dot-products to be approximately the same magnitude as before and let the training induce "close to orthogonal" transformations (ie: rotations) on the hidden state to increase the Entropy of the output distribution, rather than just "cheat" by down-scaling the hidden state.

You can see how the training using a large, but not too large value of `gamma` causes the Entropy to rise and then settle, as the model initially tries to "cheat" but then eventually settles on a better solution:

![image](https://github.com/user-attachments/assets/71fc0e18-9cf3-47e1-b9a0-74e81fa4f37b)