### PR TITLE
feature: allow checkpoint save synchronized with step save

### DIFF
--- a/examples/config.toml
+++ b/examples/config.toml
@@ -54,6 +54,7 @@ eval_after_last_step = false # do a final eval after the training completes
 logging_steps = 10  # how often to log in Tensorboard
 save_steps = 200  # how often to save the model
 checkpoint_every_n_minutes = 60  # how frequently to checkpoint training states (used for resuming training)
+# checkpoint_on_save = true  # alternative to the above, this will cause a checkpoint save every time a regular save occurs (note: this setting takes precedence over checkpoint_every_n_minutes)
 # dtype to load the underlying model weights in
 model_weight_dtype = 'bfloat16'
 # dtype for the LoRA weights

--- a/saver.py
+++ b/saver.py
@@ -45,6 +45,7 @@ class Saver:
         self.args = args
         self.config = config
         self.keep_states = config.get('keep_states', -1)
+        self.checkpoint_on_save = config.get('checkpoint_on_save', False)
         self.chrono_states = {
             'step': [],
             'global_step': [],
@@ -209,6 +210,8 @@ class Saver:
 
         if ('save_steps' in self.config and step % self.config['save_steps'] == 0) or should_manually_save:
             self.save_model(f'step{step}')
+            if self.checkpoint_on_save and not should_manually_save:
+                self.save_checkpoint(step)
 
         pending_save_best_loss = os.path.exists(os.path.join(self.save_root, ".pending_save_best_loss"))
         if pending_save_best_loss:
@@ -220,7 +223,7 @@ class Saver:
                     print(f"New best evaluation loss: {self.best_loss:.4f}")
                 os.replace(os.path.join(self.save_root, '.pending_save_best_loss'), os.path.join(self.save_root, 'best_loss.txt'))
 
-        if need_to_checkpoint(self.config) or should_manually_save:
+        if (not self.checkpoint_on_save and need_to_checkpoint(self.config)) or should_manually_save:
             self.save_checkpoint(step)
 
         if should_manually_quit:


### PR DESCRIPTION
I never really liked that checkpoints and saves are not synced up, but I respect varied opinions. This PR adds a flag to the config called `checkpoint_on_save` which, if `true`, will ignore the `checkpoint_every_n_minutes` value and save the checkpoint along with the `step`, every time.

Potentially, it may be useful to add code that raises an exception if `checkpoint_on_save` is set and `checkpoint_every_n_minutes` is present so people don't get confused, but I personally don't think it's necessary.

~Draft as I haven't tested this (yet), due to an ongoing training run.~ Tested. Works as expected on my end.