### PR TITLE
Scale number of launched warps by device warp size to avoid block thread limits

### DIFF
--- a/kernels/cross_entropy_loss.py
+++ b/kernels/cross_entropy_loss.py
@@ -15,7 +15,7 @@
 import triton
 import triton.language as tl
 import torch
-from .utils import calculate_settings, MAX_FUSED_SIZE
+from .utils import calculate_settings, MAX_FUSED_SIZE, device_warp_size
 from transformers.models.llama.modeling_llama import logger
 
 
@@ -267,7 +267,7 @@ class Fast_CrossEntropyLoss(torch.autograd.Function):
                 BLOCK_SIZE = MAX_FUSED_SIZE,
                 DO_LOGIT_SCALING = (logit_scale != 1.0),
                 LOGIT_SCALE = logit_scale,
-                num_warps  = 32,
+                num_warps  = 32 if device_warp_size() < 64 else 16,
             )
             # logsumexp(chunked_logsumexp) - x
             # Do the -x separately


### PR DESCRIPTION
Both AMD and NVIDIA gpus can launch at most 1024 threads per block.
Triton launches num_warp * device warp size threads.
All nvidia gpus have a warp size of 32 so you can launch at most 32 warps per block on those.
Some AMD gpus (GCN and CDNA) have a warp size of 64, others (RDNA) have a selectable warp size of 32 or 64, with 64 most often used by aco and llvm for game shaders and 32 being most often used by llvm in compute contexts.

We must thus limit the num_warp parameter to at most 16 on GCN and CDNA devices and on RDNA devices in warp64 mode. Unfortunately Triton dose not appear to expose this information (which is pretty silly, maybe i missed it) so as a workaround i have implemented checking the type of gpu and guessing the warp size based on that, this works fine for Nvidia gpus, and amd GCN and CDNA gpus, but for RDNA this may fail if they are in the wrong mode.

With this patch qlora-pipe now works on AMD gpus.