### PR TITLE
Fix num_warps being ending up as a float

### DIFF
--- a/kernels/utils.py
+++ b/kernels/utils.py
@@ -44,7 +44,7 @@ def calculate_settings(n):
         num_warps = 16 * warp_scalar
     elif BLOCK_SIZE >= 2048:
         num_warps = 8 * warp_scalar
-    return BLOCK_SIZE, num_warps
+    return BLOCK_SIZE, int(num_warps)
 
 
 pass


### PR DESCRIPTION
num_warps ends up as a float since https://github.com/tdrussell/qlora-pipe/pull/55 which is a problem in some cases, seams to be dependant on the model chosen, becasue triton can end up doing a bitwise operation with this value.

```
[rank1]: Traceback (most recent call last):
[rank1]:   File "scripts/qlora-pipe/train.py", line 676, in <module>
[rank1]:     metrics = model_engine.train_batch()
[rank1]:   File "scripts/qlora-pipe/engine.py", line 122, in train_batch
[rank1]:     self._exec_schedule(sched)
[rank1]:     ~~~~~~~~~~~~~~~~~~~^^^^^^^
[rank1]:   File "venv/lib/python3.13/site-packages/deepspeed/runtime/pipe/engine.py", line 1422, in _exec_schedule
[rank1]:     self._exec_instr(**cmd.kwargs)
[rank1]:     ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
[rank1]:   File "scripts/qlora-pipe/engine.py", line 313, in _exec_forward_pass
[rank1]:     outputs = super(PipelineEngine, self).forward(inputs)
[rank1]:   File "venv/lib/python3.13/site-packages/deepspeed/utils/nvtx.py", line 18, in wrapped_fn
[rank1]:     ret_val = func(*args, **kwargs)
[rank1]:   File "venv/lib/python3.13/site-packages/deepspeed/runtime/engine.py", line 1914, in forward
[rank1]:     loss = self.module(*inputs, **kwargs)
[rank1]:   File "/usr/lib/python3.13/site-packages/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl
[rank1]:     return self._call_impl(*args, **kwargs)
[rank1]:            ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
[rank1]:   File "/usr/lib/python3.13/site-packages/torch/nn/modules/module.py", line 1747, in _call_impl
[rank1]:     return forward_call(*args, **kwargs)
[rank1]:   File "venv/lib/python3.13/site-packages/deepspeed/runtime/pipe/module.py", line 388, in forward
[rank1]:     x = exec_range_func(start_idx, end_idx)(*x)
[rank1]:   File "venv/lib/python3.13/site-packages/deepspeed/runtime/pipe/module.py", line 363, in exec_func
[rank1]:     inputs = layer(inputs)
[rank1]:   File "/usr/lib/python3.13/site-packages/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl
[rank1]:     return self._call_impl(*args, **kwargs)
[rank1]:            ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
[rank1]:   File "/usr/lib/python3.13/site-packages/torch/nn/modules/module.py", line 1747, in _call_impl
[rank1]:     return forward_call(*args, **kwargs)
[rank1]:   File "scripts/qlora-pipe/layers.py", line 146, in forward
[rank1]:     cross_entropy_loss = Fast_CrossEntropyLoss.apply(flat_logits, flat_labels)
[rank1]:   File "/usr/lib/python3.13/site-packages/torch/autograd/function.py", line 575, in apply
[rank1]:     return super().apply(*args, **kwargs)  # type: ignore[misc]
[rank1]:            ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
[rank1]:   File "scripts/qlora-pipe/kernels/cross_entropy_loss.py", line 259, in forward
[rank1]:     _cross_entropy_forward[(n_rows,)](
[rank1]:     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
[rank1]:         logits,
[rank1]:         ^^^^^^^
[rank1]:     ...<8 lines>...
[rank1]:         num_warps=num_warps,
[rank1]:         ^^^^^^^^^^^^^^^^^^^^
[rank1]:     )
[rank1]:     ^
[rank1]:   File "triton/python/triton/runtime/jit.py", line 336, in <lambda>
[rank1]:     return lambda *args, **kwargs: self.run(grid=grid, warmup=False, *args, **kwargs)
[rank1]:                                    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "triton/python/triton/runtime/autotuner.py", line 379, in run
[rank1]:     return self.fn.run(*args, **kwargs)
[rank1]:            ~~~~~~~~~~~^^^^^^^^^^^^^^^^^
[rank1]:   File "triton/python/triton/runtime/jit.py", line 540, in run
[rank1]:     options = backend.parse_options(kwargs)
[rank1]:   File "triton/python/triton/backends/amd/compiler.py", line 124, in parse_options
[rank1]:     return HIPOptions(**args)
[rank1]:   File "<string>", line 24, in __init__
[rank1]:   File "triton/python/triton/backends/amd/compiler.py", line 93, in __post_init__
[rank1]:     assert self.num_warps > 0 and (self.num_warps & (self.num_warps - 1)) == 0, \
[rank1]:                                    ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
[rank1]: TypeError: unsupported operand type(s) for &: 'float' and 'float'

```